### PR TITLE
Fix Open API Instructions

### DIFF
--- a/usellm.org/content/docs/examples/nextjs-app-router.mdx
+++ b/usellm.org/content/docs/examples/nextjs-app-router.mdx
@@ -411,7 +411,7 @@ To get an OpenAI API key, you can follow these steps:
 
 2. Click on the "Get started" button or navigate to the "Product" section.
 
-3. Explore the available products and select the one that includes access to the ChatGPT API. As of my knowledge cutoff date in September 2021, the API was known as the "ChatGPT API," but please note that OpenAI may have updated or changed their offerings since then.
+3. Explore the available products and select the one that includes access to the ChatGPT API, but please note that OpenAI may have updated or changed their offerings since then.
 
 4. Review the pricing and details of the selected product to ensure it meets your requirements.
 

--- a/usellm.org/content/docs/examples/nextjs-pages-router.mdx
+++ b/usellm.org/content/docs/examples/nextjs-pages-router.mdx
@@ -402,7 +402,7 @@ To get an OpenAI API key, you can follow these steps:
 
 2. Click on the "Get started" button or navigate to the "Product" section.
 
-3. Explore the available products and select the one that includes access to the ChatGPT API. As of my knowledge cutoff date in September 2021, the API was known as the "ChatGPT API," but please note that OpenAI may have updated or changed their offerings since then.
+3. Explore the available products and select the one that includes access to the ChatGPT API, but please note that OpenAI may have updated or changed their offerings since then.
 
 4. Review the pricing and details of the selected product to ensure it meets your requirements.
 


### PR DESCRIPTION
Remove the text `As of my knowledge cutoff date in September 2021, the API was known as the "ChatGPT API`