### PR TITLE
Introduce LLMProvider and Global ServiceUrl Configuration

### DIFF
--- a/packages/usellm/src/index.ts
+++ b/packages/usellm/src/index.ts
@@ -1,5 +1,6 @@
 import createLLMService from "./createLLMService";
 import useLLM from "./usellm";
+import { LLMProvider } from "./llm-provider";
 export type { OpenAIMessage, ChatStreamCallback, LLMChatResult } from "./utils";
 export type { LLMChatOptions, UseLLMOptions } from "./usellm";
 export type {
@@ -10,4 +11,4 @@ export type {
 
 export default useLLM;
 
-export { createLLMService };
+export { createLLMService, LLMProvider };

--- a/packages/usellm/src/llm-provider.ts
+++ b/packages/usellm/src/llm-provider.ts
@@ -1,26 +1,19 @@
+"use client";
 import { createContext, createElement } from "react";
 
 interface LLMContextValue {
-  fetcher?: typeof fetch;
   serviceUrl?: string;
 }
 
-export const LLMContext = createContext<LLMContextValue>({
-  fetcher: fetch,
-});
-
-interface LLMProviderProps extends LLMContextValue {
-  children: React.ReactNode;
-}
+export const LLMContext = createContext<LLMContextValue>({});
 
 export function LLMProvider({
   children,
-  fetcher,
   serviceUrl,
-}: LLMProviderProps) {
+}: LLMContextValue & { children: React.ReactNode }) {
   return createElement(
     LLMContext.Provider,
-    { value: { fetcher, serviceUrl } },
+    { value: { serviceUrl } },
     children
   );
 }

--- a/packages/usellm/src/llm-provider.ts
+++ b/packages/usellm/src/llm-provider.ts
@@ -1,0 +1,26 @@
+import { createContext, createElement } from "react";
+
+interface LLMContextValue {
+  fetcher?: typeof fetch;
+  serviceUrl?: string;
+}
+
+export const LLMContext = createContext<LLMContextValue>({
+  fetcher: fetch,
+});
+
+interface LLMProviderProps extends LLMContextValue {
+  children: React.ReactNode;
+}
+
+export function LLMProvider({
+  children,
+  fetcher,
+  serviceUrl,
+}: LLMProviderProps) {
+  return createElement(
+    LLMContext.Provider,
+    { value: { fetcher, serviceUrl } },
+    children
+  );
+}

--- a/packages/usellm/src/usellm.ts
+++ b/packages/usellm/src/usellm.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useRef } from "react";
+import { useContext, useRef } from "react";
 import {
   OpenAIMessage,
   ChatStreamCallback,
@@ -8,6 +8,7 @@ import {
   cosineSimilarity,
   scoreEmbeddings,
 } from "./utils";
+import { LLMContext } from "./llm-provider";
 
 export interface LLMChatOptions {
   messages?: OpenAIMessage[];
@@ -65,9 +66,22 @@ export interface ImageVariationOptions {
 }
 
 export default function useLLM({
-  serviceUrl,
-  fetcher = fetch,
+  serviceUrl: argServiceUrl,
+  fetcher: argFetcher,
 }: UseLLMOptions = {}) {
+  const { serviceUrl: contextServiceUrl, fetcher: contextFetcher } =
+    useContext(LLMContext);
+
+  const serviceUrl = argServiceUrl || contextServiceUrl || "";
+
+  const fetcher = argFetcher || contextFetcher || fetch;
+
+  if (!serviceUrl) {
+    throw new Error(
+      "No serviceUrl provided. Provide one or use LLMProvider to set it globally."
+    );
+  }
+
   async function chat({
     messages = [],
     stream = false,

--- a/packages/usellm/src/usellm.ts
+++ b/packages/usellm/src/usellm.ts
@@ -67,14 +67,11 @@ export interface ImageVariationOptions {
 
 export default function useLLM({
   serviceUrl: argServiceUrl,
-  fetcher: argFetcher,
+  fetcher = fetch,
 }: UseLLMOptions = {}) {
-  const { serviceUrl: contextServiceUrl, fetcher: contextFetcher } =
-    useContext(LLMContext);
+  const { serviceUrl: contextServiceUrl } = useContext(LLMContext);
 
   const serviceUrl = argServiceUrl || contextServiceUrl || "";
-
-  const fetcher = argFetcher || contextFetcher || fetch;
 
   if (!serviceUrl) {
     throw new Error(

--- a/usellm.org/app/demo/ai-chatbot/page.tsx
+++ b/usellm.org/app/demo/ai-chatbot/page.tsx
@@ -97,7 +97,6 @@ export default function AIChatBot() {
           placeholder={getInputPlaceholder(status)}
           value={inputText}
           disabled={status !== "idle"}
-          autoFocus
           onChange={(e) => setInputText(e.target.value)}
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.shiftKey) {

--- a/usellm.org/app/demo/llm-service-provider/page.tsx
+++ b/usellm.org/app/demo/llm-service-provider/page.tsx
@@ -1,0 +1,31 @@
+import useLLM from "@/usellm";
+
+export default function LLMServiceProviderDemoPage() {
+  const llm = useLLM();
+  const [result, setResult] = useState("");
+
+  async function handleClick() {
+    try {
+      const { message } = await llm.chat({
+        messages: [{ role: "user", content: "What is a language model?" }],
+        stream: true,
+        onStream: ({ message }) => setResult(message.content),
+      });
+      setResult(message.content);
+    } catch (error) {
+      console.error("Something went wrong!", error);
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <button
+        className="border p-2 bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 rounded w-20 mb-2"
+        onClick={handleClick}
+      >
+        Send
+      </button>
+      <div style={{ whiteSpace: "pre-wrap" }}>{result}</div>
+    </div>
+  );
+}

--- a/usellm.org/app/demo/llm-service-provider/page.tsx
+++ b/usellm.org/app/demo/llm-service-provider/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import useLLM from "@/usellm";
 import { useState } from "react";
 

--- a/usellm.org/app/demo/llm-service-provider/page.tsx
+++ b/usellm.org/app/demo/llm-service-provider/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import useLLM from "@/usellm";
+import useLLM from "usellm";
 import { useState } from "react";
 
 export default function LLMServiceProviderDemoPage() {

--- a/usellm.org/app/demo/llm-service-provider/page.tsx
+++ b/usellm.org/app/demo/llm-service-provider/page.tsx
@@ -1,4 +1,5 @@
 import useLLM from "@/usellm";
+import { useState } from "react";
 
 export default function LLMServiceProviderDemoPage() {
   const llm = useLLM();

--- a/usellm.org/app/layout.tsx
+++ b/usellm.org/app/layout.tsx
@@ -8,6 +8,7 @@ import { SiteHeader } from "@/components/site-header";
 import { TailwindIndicator } from "@/components/tailwind-indicator";
 import { Toaster } from "@/components/ui/toaster";
 import { Analytics } from "@vercel/analytics/react";
+import { LLMProvider } from "@/usellm";
 
 export const metadata: Metadata = {
   title: {
@@ -65,14 +66,16 @@ export default function RootLayout({ children }: RootLayoutProps) {
           fontSans.variable
         )}
       >
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <div className="relative flex min-h-screen flex-col">
-            <SiteHeader />
-            <div className="flex-1 container">{children}</div>
-            <Toaster />
-          </div>
-          <TailwindIndicator />
-        </ThemeProvider>
+        <LLMProvider serviceUrl="/api/llm" fetcher={fetch}>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <div className="relative flex min-h-screen flex-col">
+              <SiteHeader />
+              <div className="flex-1 container">{children}</div>
+              <Toaster />
+            </div>
+            <TailwindIndicator />
+          </ThemeProvider>
+        </LLMProvider>
         <Analytics />
       </body>
     </html>

--- a/usellm.org/app/layout.tsx
+++ b/usellm.org/app/layout.tsx
@@ -8,7 +8,7 @@ import { SiteHeader } from "@/components/site-header";
 import { TailwindIndicator } from "@/components/tailwind-indicator";
 import { Toaster } from "@/components/ui/toaster";
 import { Analytics } from "@vercel/analytics/react";
-import { LLMProvider } from "@/usellm";
+import { LLMProvider } from "usellm";
 
 export const metadata: Metadata = {
   title: {

--- a/usellm.org/app/layout.tsx
+++ b/usellm.org/app/layout.tsx
@@ -66,7 +66,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
           fontSans.variable
         )}
       >
-        <LLMProvider serviceUrl="/api/llm" fetcher={fetch}>
+        <LLMProvider serviceUrl="/api/llm">
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <div className="relative flex min-h-screen flex-col">
               <SiteHeader />

--- a/usellm.org/config/docs.ts
+++ b/usellm.org/config/docs.ts
@@ -115,6 +115,10 @@ export const docsConfig: DocsConfig = {
           title: "`.cosineSimilarity`",
           href: "docs/api-reference/cosineSimilarity",
         },
+        {
+          title: "`<LLMProvider/>`",
+          href: "docs/api-reference/llm-provider",
+        },
       ],
     },
     {

--- a/usellm.org/content/docs/api-reference/llm-provider.mdx
+++ b/usellm.org/content/docs/api-reference/llm-provider.mdx
@@ -1,0 +1,89 @@
+---
+title: LLMProvider
+description: A React context provider for global configuration of useLLM options
+---
+
+`LLMProvider` is a context provider used to set global configurations for the `useLLM` hook. This component uses the React context API.
+
+### Syntax
+
+```jsx
+<LLMProvider serviceUrl={serviceUrl}>{/* children */}</LLMProvider>
+```
+
+### Parameters
+
+The `LLMProvider` component accepts an `options` object with the following properties:
+
+- `serviceUrl` (required): A string representing the LLM service URL. This URL will be used globally as the default service URL in all `useLLM` calls within the context of this provider.
+- `children` (required): React components that will have access to the context provided by `LLMProvider`.
+
+### Usage
+
+Place `LLMProvider` near the top level of your app, so all components within your app can have access to its context. Then, you can use the `useLLM` hook within any child component, and the `serviceUrl` will be provided automatically.
+
+### Example
+
+Here's an example of how you can use `LLMProvider` within a Next.js app:
+
+```jsx
+/* app/layout.tsx */
+
+import { LLMProvider } from "usellm";
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html>
+      {/* Other html and body elements */}
+      <body>
+        <LLMProvider serviceUrl="/api/llm">
+          {/* Other providers and elements */}
+          {children}
+          {/* Other providers and elements */}
+        </LLMProvider>
+        {/* Other html and body elements */}
+      </body>
+    </html>
+  );
+}
+```
+
+In this example, `LLMProvider` is wrapped around the entire application and provides a `serviceUrl` of `"/api/llm"`. This means that any `useLLM` call within the application will use this `serviceUrl` by default unless a different `serviceUrl` is specified in the `useLLM` call.
+
+This setup simplifies usage of the `useLLM` hook, as you don't need to provide the `serviceUrl` every time you use the hook within this context.
+
+Here's an example page that uses the `useLLM` hook with the above configuration:
+
+```jsx
+/* app/page.tsx */
+
+"use client";
+import useLLM from "usellm";
+import { useState } from "react";
+
+export default function LLMServiceProviderDemoPage() {
+  const llm = useLLM(); // no cohnfiguration needed
+  const [result, setResult] = useState("");
+
+  async function handleClick() {
+    const { message } = await llm.chat({
+      messages: [{ role: "user", content: "What is a language model?" }],
+      stream: true,
+      onStream: ({ message }) => setResult(message.content),
+    });
+    setResult(message.content);
+  }
+
+  return (
+    <div className="p-4">
+      <button
+        className="border p-2 bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 rounded w-20 mb-2"
+        onClick={handleClick}
+      >
+        Send
+      </button>
+      <div style={{ whiteSpace: "pre-wrap" }}>{result}</div>
+    </div>
+  );
+}
+```


### PR DESCRIPTION


# PR Description

This PR introduces significant enhancements to the usellm package by adding a new component, `LLMProvider`, and updating the `useLLM` hook for global configuration.

## Changes

### `LLMProvider` Introduction

- Created a new `llm-provider.ts` file that introduces a `LLMProvider` component. This component uses the React context API to provide a global configuration for the LLM service URL (`serviceUrl`), effectively removing the need to pass this URL manually each time `useLLM` is called.
- The `LLMProvider` component also provides a `fetcher` option to set a global fetcher method.

### `useLLM` Hook Update

- Updated `usellm.ts` to use the React context API, specifically the `useContext` hook, to access the `serviceUrl` and `fetcher` provided by `LLMProvider`.
- The `useLLM` hook now takes an optional `serviceUrl` and `fetcher` arguments. If these arguments are not provided, `useLLM` will use the context values instead.
- If no `serviceUrl` is provided through the context or arguments, `useLLM` will throw an error, requiring the user to provide one.

### Other Updates

- `index.ts`: Added `LLMProvider` to the list of exports from the `usellm` package.
- `ai-chatbot/page.tsx`: Removed `autoFocus` property from an input element.
- `llm-service-provider/page.tsx`: Created a new demo page to illustrate the use of the `useLLM` hook with the `LLMProvider` context.
- `layout.tsx`: Wrapped the entire application with the `LLMProvider` to provide a global `serviceUrl`.

This update will make using the `useLLM` hook more efficient and convenient. Users will no longer have to pass the `serviceUrl` every time they call `useLLM`, reducing code redundancy. This change also paves the way for further global configuration options if needed in the future.