### PR TITLE
Add registerAction and callAction methods

### DIFF
--- a/packages/usellm/src/usellm.ts
+++ b/packages/usellm/src/usellm.ts
@@ -39,6 +39,11 @@ export interface GenerateImageOptions {
   size?: "256x256" | "512x512" | "1024x1024";
 }
 
+export interface LLMCallActionOptions {
+  $action: string;
+  [key: string]: any;
+}
+
 export interface UseLLMOptions {
   serviceUrl?: string;
   fetcher?: typeof fetch;
@@ -299,7 +304,22 @@ export default function useLLM({
     });
   }
 
+  async function callAction(options: LLMCallActionOptions) {
+    const response = await fetcher(`${serviceUrl}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options),
+    });
+
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    return response.json();
+  }
+
   return {
+    callAction,
     chat,
     record,
     stopRecording,


### PR DESCRIPTION
This PR brings several enhancements and features to the `LLMService` and introduces the ability to incorporate custom actions.

### Major Changes:
1. **Addition of Custom Actions:** The `LLMService` class now includes a `customActions` map that stores custom actions. These actions can be registered with the `registerAction` method, where each action is a function that takes an options object and returns a Promise of either a `ReadableStream` or an `object`.

2. **Refactor Action Handling:** The handling of actions within the `LLMService` has been refactored to a separate `callAction` method, thereby reducing the complexity and improving readability. This also allows for better integration of custom actions.

3. **Addition of `callAction` to `useLLM`:** To integrate the custom actions functionality with the service's consumers, a new `callAction` method is added to the `useLLM` hook. This method makes a POST request to the service with a provided options object and returns the response.

4. **Simplified Return Values:** To improve the developer experience and consistency, several methods in the `LLMService` class have been modified to return JSON directly, instead of stringified JSON.

These updates will make it easier for developers to extend the functionality of the `LLMService` by incorporating custom actions and should improve the overall usability of the system.