### PR TITLE
Fix meta tags on homepage

### DIFF
--- a/usellm.org/app/layout.tsx
+++ b/usellm.org/app/layout.tsx
@@ -50,6 +50,13 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: "summary_large_image",
+    title: `${siteConfig.name} - React Hooks for Large Language Models`,
+    description: siteConfig.description,
+    images: [siteConfig.ogImage],
+    creator: "@usellmteam",
+  },
 };
 
 interface RootLayoutProps {

--- a/usellm.org/app/page.tsx
+++ b/usellm.org/app/page.tsx
@@ -11,7 +11,6 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { ChevronRight } from "lucide-react";
 import { SiteFooter } from "@/components/site-footer";
-import { ExamplesNav } from "@/components/examples-nav";
 import { HomePageDemo } from "@/components/home-page-demo";
 
 export default function IndexPage() {
@@ -50,8 +49,7 @@ export default function IndexPage() {
             </Link>
           </div>
         </PageHeader>
-        <div id="demo" />
-        <ExamplesNav />
+
         <HomePageDemo />
       </div>
       <div className="flex-1" />

--- a/usellm.org/components/examples-nav.tsx
+++ b/usellm.org/components/examples-nav.tsx
@@ -1,29 +1,37 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
 
 import { cn } from "@/lib/utils";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { HOME_PAGE_DEMOS } from "@/config/demos";
 
-interface ExamplesNavProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface ExamplesNavProps extends React.HTMLAttributes<HTMLDivElement> {
+  current: string;
+  setCurrent: (id: string) => void;
+}
 
-export function ExamplesNav({ className, ...props }: ExamplesNavProps) {
-  const searchParams = useSearchParams();
-  const page = searchParams.get("demo") || "ai-chatbot";
-
+export function ExamplesNav({
+  current,
+  setCurrent,
+  className,
+  ...props
+}: ExamplesNavProps) {
   return (
     <div className="relative">
       <ScrollArea>
         <div className={cn("mb-4 flex items-center", className)} {...props}>
           {HOME_PAGE_DEMOS.map((example) => (
             <Link
-              href={"/?demo=" + example.id}
+              href={"#"}
+              onClick={(e) => {
+                e.preventDefault();
+                setCurrent(example.id);
+              }}
               key={example.id}
               className={cn(
                 "flex items-center px-4 flex-shrink-0",
-                page === example.id
+                current === example.id
                   ? "font-bold text-primary"
                   : "font-medium text-muted-foreground"
               )}

--- a/usellm.org/components/home-page-demo.tsx
+++ b/usellm.org/components/home-page-demo.tsx
@@ -1,35 +1,39 @@
 "use client";
 import { HOME_PAGE_DEMOS } from "@/config/demos";
 import { Icons } from "./icons";
-import { useSearchParams } from "next/navigation";
+import { ExamplesNav } from "./examples-nav";
+import { useState } from "react";
 
 export function HomePageDemo() {
-  const searchParams = useSearchParams();
-  const id = searchParams.get("demo") || "ai-chatbot";
+  const [current, setCurrent] = useState("ai-chatbot");
 
-  const page = HOME_PAGE_DEMOS.find((demo) => demo.id === id);
+  const page = HOME_PAGE_DEMOS.find((demo) => demo.id === current);
 
   if (!page) {
     return null;
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border bg-background shadow-xl w-full h-[500px] flex flex-col mb-8">
-      <div className="w-full shadow dark:border-b">
-        <div className="w-full px-4 h-14 flex items-center mx-auto justify-between">
-          <span className="text-lg font-bold ">Live Demo</span>
-          {page.sourceUrl && (
-            <a
-              target="_blank"
-              className="hover:text-blue-600 flex items-center"
-              href={page.sourceUrl}
-            >
-              Source <Icons.externalLink className="inline ml-1" size={16} />
-            </a>
-          )}
+    <>
+      <div id="demo" />
+      <ExamplesNav current={current} setCurrent={setCurrent} />
+      <div className="overflow-hidden rounded-lg border bg-background shadow-xl w-full h-[500px] flex flex-col mb-8">
+        <div className="w-full shadow dark:border-b">
+          <div className="w-full px-4 h-14 flex items-center mx-auto justify-between">
+            <span className="text-lg font-bold ">Live Demo</span>
+            {page.sourceUrl && (
+              <a
+                target="_blank"
+                className="hover:text-blue-600 flex items-center"
+                href={page.sourceUrl}
+              >
+                Source <Icons.externalLink className="inline ml-1" size={16} />
+              </a>
+            )}
+          </div>
         </div>
+        <page.component />
       </div>
-      <page.component />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Using `useSearchParams` was messing up the meta tags on the statically generated home page. It is fixed now.